### PR TITLE
fix: autoremove should be stand alone

### DIFF
--- a/roles/system/tasks/fedora.yml
+++ b/roles/system/tasks/fedora.yml
@@ -30,7 +30,6 @@
     name: "*"
     update_cache: true
     state: latest
-    autoremove: true
   become: true
 
 - name: "System | Install system76 Packages when on system76 machine type"


### PR DESCRIPTION
fix: autoremove only used as stand alone or when state: absent is used in the task. I will create another task to do clean up of unused packages at the end of the role installations. 