### PR TITLE
fix: system76 drivers change enable repo command

### DIFF
--- a/roles/system/tasks/fedora.yml
+++ b/roles/system/tasks/fedora.yml
@@ -15,9 +15,9 @@
     state: present
   become: true
 
-- name: Enable Fedora Copr for LXD
+- name: Enable Fedora Copr for System76 drivers on fedora 
   command:
-      cmd: dnf copr enable -y dnf copr enable szydell/system76
+      cmd: copr enable szydell/system76
       creates: /_copr:copr.fedorainfracloud.org:szydell:system76.repo
 
 - name: Install DNF plugins core


### PR DESCRIPTION
I think I only need to do the copr enable repo command so remove enabling copr itself. Dnf package manager should enable copr repos at a default install 