### PR TITLE
fix: comment out system76 driver install atm needs a lot more work

### DIFF
--- a/roles/system/tasks/fedora.yml
+++ b/roles/system/tasks/fedora.yml
@@ -32,18 +32,18 @@
     state: latest
   become: true
 
-- name: "System | Install system76 Packages when on system76 machine type"
-  ansible.builtin.dnf:
-    name:
-      - system76-dkms
-      - system76-power
-      - system76-drivers
-      - system76-firmware
-      - system76-io-dkms
-      - system76-acpi-dkms
-      - firmware-manager
-    state: present
-  become: true
+# - name: "System | Install system76 Packages when on system76 machine type"
+#   ansible.builtin.dnf:
+#     name:
+#       - system76-dkms
+#       - system76-power
+#       - system76-drivers
+#       - system76-firmware
+#       - system76-io-dkms
+#       - system76-acpi-dkms
+#       - firmware-manager
+#     state: present
+#   become: true
 
 - name: "System | Install Packages"
   ansible.builtin.dnf:


### PR DESCRIPTION
This task will need a lot more detection to determine it will run on the correct machine etc. So commenting out now will rework on this once the main playbooks/roles are working on fedora first