### PR TITLE
fix: remove open-iscsi package I don't need and not in dnf default. T…

### DIFF
--- a/roles/system/tasks/fedora.yml
+++ b/roles/system/tasks/fedora.yml
@@ -49,7 +49,6 @@
   ansible.builtin.dnf:
     name:
       - jq
-      - open-iscsi
       - git 
       - git-lfs
       - htop


### PR DESCRIPTION
…his task can be cleaned right up really packages called for install elsewhere more relevant