### PR TITLE
feat: added system detection step to know what type of system model i…

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -4,6 +4,11 @@
   connection: local
 
   pre_tasks:
+    - name: Detect system type
+      ansible.builtin.import_tasks: pre_tasks/whatami.yml
+      tags:
+        - always
+      
     - name: Detect WSL
       ansible.builtin.import_tasks: pre_tasks/detect_wsl.yml
       tags:

--- a/pre_tasks/whatami.yml
+++ b/pre_tasks/whatami.yml
@@ -1,0 +1,7 @@
+---
+- name: "Detect system type"
+  setup: 
+    filter: ansible_product_name
+  set_fact:
+    system_type: "{{ ansible_product_name }}"
+  tags: always

--- a/roles/system/tasks/fedora.yml
+++ b/roles/system/tasks/fedora.yml
@@ -17,8 +17,10 @@
 
 - name: Enable Fedora Copr for System76 drivers on fedora 
   command:
-      cmd: copr enable szydell/system76
-      creates: /_copr:copr.fedorainfracloud.org:szydell:system76.repo
+    cmd: copr enable szydell/system76
+    creates: /_copr:copr.fedorainfracloud.org:szydell:system76.repo
+  when: system_type == "Oryx Pro"
+
 
 - name: Install DNF plugins core
   ansible.builtin.dnf:
@@ -44,6 +46,7 @@
 #       - firmware-manager
 #     state: present
 #   become: true
+#   when: system_type == "Oryx Pro"
 
 - name: "System | Install Packages"
   ansible.builtin.dnf:


### PR DESCRIPTION
This is mainly for the playbook to detect when it's running on my system76 laptop and install the copr repo and system76 drivers required on that machine.